### PR TITLE
Fix compose.yml volume source for build packages service

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -75,7 +75,7 @@ services:
                   source: './NSO-vol/NSO2'
                   target: '/nso2'
                 - type: bind
-                  source: './NSO-log-vol/NSO1'
+                  source: './NSO-log-vol/NSO2'
                   target: '/log_nso2'
 
 


### PR DESCRIPTION
Change following:
`     - type: bind
      source: './NSO-vol/NSO1'
      target: '/nso2' `

to:
`     - type: bind
      source: './NSO-vol/NSO2'
      target: '/nso2' `